### PR TITLE
chore: cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ addons:
 env:
   global:
     - BASE_NAME=embetty-$TRAVIS_TAG
+cache:
+  yarn: true
+  directories:
+    - node_modules
 script:
 - yarn test
 - yarn build


### PR DESCRIPTION
### Summary

This enables the yarn cache and caches also node_modules to decrease the time needed for consecutive builds.

### Motivation

Faster CI builds.

### Review

Trigger a new build after after this change.
