### PR TITLE
Add extra 'activated' event

### DIFF
--- a/lib/embed/video.js
+++ b/lib/embed/video.js
@@ -16,6 +16,7 @@ export default class Video extends Observable(Embed) {
 
   activate() {
     this.shadowRoot.innerHTML = this.impl.iframe
+    this.emit('activated')
   }
 
   get playButton() {


### PR DESCRIPTION
### Summary

Additionally I suggest an event after clicking on'playButton'   ##->'activated'. 

### Issue 
#30 

`$('embetty-video').on("activated", function () {
      //your code here
});`
### Motivation
I will use this event to trigger extra functionality to the embedded video/user

### Review
Use the example code

### References
@see event 'initialized'
