### PR TITLE
fix tweet links to work on both new and legacy twitter, close #65

### DIFF
--- a/lib/embed/tweet.js
+++ b/lib/embed/tweet.js
@@ -163,7 +163,7 @@ class Tweet extends Observable(Embed) {
           </a>
         {{/hasLinks}}
 
-        <a href="{{twitterUrl}}" target="_blank" rel="noopener" id="created-at">
+        <a href="{{twitterUrl}}" target="_blank" rel="noopener" id="created-at" class="tweet__link">
           <time datetime="{{createdAt.toISOString}}">{{createdAt.toLocaleString}}</time>
           via Twitter
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400"><defs><style>.cls-1{fill:none;}.cls-2{fill:#1da1f2;}</style></defs><path class="cls-2" d="M153.62,301.59c94.34,0,145.94-78.16,145.94-145.94,0-2.22,0-4.43-.15-6.63A104.36,104.36,0,0,0,325,122.47a102.38,102.38,0,0,1-29.46,8.07,51.47,51.47,0,0,0,22.55-28.37,102.79,102.79,0,0,1-32.57,12.45,51.34,51.34,0,0,0-87.41,46.78A145.62,145.62,0,0,1,92.4,107.81a51.33,51.33,0,0,0,15.88,68.47A50.91,50.91,0,0,1,85,169.86c0,.21,0,.43,0,.65a51.31,51.31,0,0,0,41.15,50.28,51.21,51.21,0,0,1-23.16.88,51.35,51.35,0,0,0,47.92,35.62,102.92,102.92,0,0,1-63.7,22A104.41,104.41,0,0,1,75,278.55a145.21,145.21,0,0,0,78.62,23"/></svg>

--- a/lib/embed/tweet.js
+++ b/lib/embed/tweet.js
@@ -53,7 +53,7 @@ class Tweet extends Observable(Embed) {
   }
 
   get twitterUrl() {
-    return `https://twitter.com/statuses/${this._data.id_str}`
+    return `https://twitter.com/${this._data.user.screen_name}/status/${this._data.id_str}`
   }
 
   get createdAt() {

--- a/test/tweet.js
+++ b/test/tweet.js
@@ -53,6 +53,14 @@ describe('Tweet', () => {
     })
   })
 
+  it('tweet link should contain the username and the tweet id', async () => {
+    const { element } = await createTweet(Tweets.text)
+    const links = [...element.shadowRoot.querySelectorAll('.tweet__link')]
+    assert.strictEqual(links.length, 1)
+    assert.ok(links[0].getAttribute('href').includes('SiLVAFiSH'));
+    assert.ok(links[0].getAttribute('href').includes('934029337019416579'));
+  })
+
   describe('Tweet body', () => {
     it('should replace hash tags', async () => {
       const { query } = await createTweet(Tweets.hashTag.valid)


### PR DESCRIPTION
### Summary

As outlined in #65 the tweet links in embedded tweets do not work in mobile or legacy twitter. This makes embetty generate links that work in legacy, mobile and modern twitter.

### Motivation

So all users can click the link underneath an embedded tweet 

### Review

a) using the supplied test
b) do the following:
  1. switch twitter to legacy mode, follow embedded link
  2. switch twitter to modern mode, follow embedded link
