### PR TITLE
fix logo display after upgrading to raw-loader >= 2.0.0

### DIFF
--- a/lib/embed.js
+++ b/lib/embed.js
@@ -2,7 +2,7 @@ import { wait } from './util'
 import urljoin from 'url-join'
 
 // eslint-disable-next-line
-const EMBETTY_LOGO = require('!raw-loader!../assets/embetty.svg').toString()
+const EMBETTY_LOGO = require('!raw-loader!../assets/embetty.svg').default.toString()
 
 export default class Embed extends window.HTMLElement {
   constructor() {


### PR DESCRIPTION
<!--
PLEASE WRITE YOUR MESSAGE IN ENGLISH. BE NICE.

THANK YOU FOR CONTRIBUTING TO THIS PROJECT.
-->
### Summary
after the upgrade of `raw-loader` to ^3.0.0, display of the embetty logo on top of the embedded media broke. instead it was showing "powered by [object Module]", since `raw-loader` v2 went to use ES Module export instead of CommonJS.
this PR keeps the require statement & only modified it to make sure it's specifically targeting the default export of `raw-loader`.
<!--
DESCRIBE WHAT THIS PULL REQUEST DOES

INCLUDE CODE EXAMPLES AND SCREENSHOTS IF APPLICABLE
-->

### Motivation
update the loading of the logo svg to not have an object converted to String showing.
<!--
EXPLAIN WHY THIS PULL REQUEST SHOULD BE MERGED
-->

### Review
can be confirmed by trying out any version of `embetty.js` >= 1.1.7 in the browser.
<!--
EXPLAIN HOW THE CHANGES CAN BE TESTED
-->

### References
https://github.com/webpack-contrib/raw-loader/releases/tag/v2.0.0
<!--
LIST OTHER RELEVANT INFOMATION
-->
