### PR TITLE
inherit include-thread from parent tweet

### DIFF
--- a/lib/embed/tweet.js
+++ b/lib/embed/tweet.js
@@ -6,9 +6,10 @@ import Observable from '../observable'
 const CSS = require('!css-loader!postcss-loader!sass-loader!./tweet.scss').toString()
 
 class Tweet extends Observable(Embed) {
-  constructor(status, parent) {
+  constructor(status, parent, options = {}) {
     super()
     if (status) this.setAttribute('status', status)
+    if ('include-thread' in options) this.setAttribute('include-thread', '')
     this.parent = parent
 
     this.on('initialized', () => { this.appendAnsweredTweet() })
@@ -17,7 +18,7 @@ class Tweet extends Observable(Embed) {
 
   appendAnsweredTweet() {
     if (!this.isReply || !this.hasAttribute('include-thread')) return
-    const answered = new Tweet(this.answeredTweetId, this)
+    const answered = new Tweet(this.answeredTweetId, this, { 'include-thread': '' })
     answered.classList.add('answered')
     this.shadowRoot.insertBefore(answered, this.shadowRoot.firstChild)
   }

--- a/test/tweet.js
+++ b/test/tweet.js
@@ -91,9 +91,10 @@ describe('Tweet', () => {
       assert.strictEqual(element.shadowRoot.querySelector('embetty-tweet'), null)
     })
 
-    it('should show tweet and thread due to include-thread attribute', async () => {
+    it('should show thread and inherit include-thread attribute on being set', async () => {
       const { element } = await createTweet(Tweets.reply, { 'include-thread': '' })
-      assert.ok(element.shadowRoot.querySelector('embetty-tweet'))
+      const parent = element.shadowRoot.querySelector('embetty-tweet')
+      assert.ok(parent && parent.hasAttribute('include-thread'))
     })
   })
 })


### PR DESCRIPTION
### Summary

The include-thread parameter was *not* inherited to parent tweets in the thread. Therefore only one parent tweet was shown, instead of the _whole_ thread above, contrary to what `include-thread` indicates. This small change fixes this by inheriting the include-thread parameter to parent tweets, whole threads are now shown if `include-thread` is used.

