### PR TITLE
Feature/support twitter videos

### DIFF
--- a/lib/embed/tweet.js
+++ b/lib/embed/tweet.js
@@ -99,6 +99,15 @@ class Tweet extends Observable(Embed) {
       m.imageUrl = `${this.url}-images-${idx}`
       if (m.type === 'video') {
         m.targetUrl = m.expanded_url
+        m.video = {
+          imageUrl: m.imageUrl,
+          videoUrls: m.video_info.variants.map((m, idx) => {
+            return {
+              url: m.url,
+              contentType: m.content_type
+            }
+          })
+        }
       } else {
         m.targetUrl = m.imageUrl
       }
@@ -153,7 +162,16 @@ class Tweet extends Observable(Embed) {
         {{#hasMedia}}
           <section class="media-{{media.length}}" id="media">
             {{#media}}
-              <a target="_blank" href="{{targetUrl}}"><img src="{{imageUrl}}"></a>
+              {{#video}}
+                <video poster="{{imageUrl}}" controls preload="none">
+                  {{#videoUrls}}
+                    <source src="{{url}}" type="{{contentType}}"></source>
+                  {{/videoUrls}}
+                </video>
+              {{/video}}
+              {{^video}}
+                <a target="_blank" href="{{targetUrl}}"><img src="{{imageUrl}}"></a>
+              {{/video}}
             {{/media}}
           </section>
         {{/hasMedia}}

--- a/lib/embed/tweet.js
+++ b/lib/embed/tweet.js
@@ -97,6 +97,11 @@ class Tweet extends Observable(Embed) {
     const media = extended.media || []
     return media.map((m, idx) => {
       m.imageUrl = `${this.url}-images-${idx}`
+      if (m.type === 'video') {
+        m.targetUrl = m.expanded_url
+      } else {
+        m.targetUrl = m.imageUrl
+      }
       return m
     })
   }
@@ -148,7 +153,7 @@ class Tweet extends Observable(Embed) {
         {{#hasMedia}}
           <section class="media-{{media.length}}" id="media">
             {{#media}}
-              <a target="_blank" href="{{imageUrl}}"><img src="{{imageUrl}}"></a>
+              <a target="_blank" href="{{targetUrl}}"><img src="{{imageUrl}}"></a>
             {{/media}}
           </section>
         {{/hasMedia}}

--- a/lib/embed/tweet.scss
+++ b/lib/embed/tweet.scss
@@ -109,7 +109,7 @@ $quoteLineWidth: 4px;
       }
     }
 
-    img {
+    img, video {
       max-width: 100%;
       width: 100%;
       height: 100%;


### PR DESCRIPTION
### Summary

This PR changes the handling of twitter posts with embedded videos. Instead of linking to a still image of the video, a HTML video element (with `preload="none"` for data privacy) is embedded into the post.

(refs heiseonline/embetty-server#33)

### Motivation

The current twitter video handling is broken (see above).

### Review

Embed a twitter post which includes a video.