### PR TITLE
Added a "|" (pipe) to the hashtag regex because it is often used as a delimiter.

### DIFF
--- a/lib/embed/tweet.js
+++ b/lib/embed/tweet.js
@@ -83,7 +83,7 @@ class Tweet extends Observable(Embed) {
 
   get fullText() {
     return this._data.full_text
-      .replace(/#([^\s-]+)/g, (hashTag, word) => {
+      .replace(/#([^\s-|]+)/g, (hashTag, word) => {
         return `<a href="https://twitter.com/hashtag/${word}">${hashTag}</a>`
       })
       .replace(/@(\w+)/g, (name, word) => {


### PR DESCRIPTION
### Summary

Displays and links twitter hashtags correctly if a pipe is used as a delimiter. i.e. for the pluralization of a hashtag

### Review

The changes can be tested by embedding this [tweet](https://twitter.com/fabiantest2/status/1294338186840285184) for example.
Example: "#hashtag|s" should only highlight and link to "#hashtag"

### References

The actual hashtag validation twitter does is way more complex and can be found here: https://github.com/twitter/twitter-text/tree/master/js/src

Edit: Test failed. Guess it's because of the missing twitter credentials?