### PR TITLE
Added aria-label for video play-button

### DIFF
--- a/lib/embed/video.js
+++ b/lib/embed/video.js
@@ -67,7 +67,7 @@ export default class Video extends Observable(Embed) {
   static get template() {
     return `
       <style>${CSS}</style>
-      <button type="button" id="playbutton">
+      <button type="button" id="playbutton" aria-label="Abspielen">
         <svg xmlns="http://www.w3.org/2000/svg" width="72" height="72" viewBox="0 0 2000 2000" fill="#fff" class="video-playbutton">
             <g transform="matrix(1.05356,0,0,1.03089,24.9824,-12.7689)">
               <ellipse cx="925.453" cy="982.42" rx="906.453" ry="926.382" style="fill:black;fill-opacity:0.65;stroke:white;stroke-width:70px;"></ellipse>


### PR DESCRIPTION
### Summary

Added a aria-label for the video play-button.

### Motivation

Improve the accessibility of the project for blind and visually impaired users.

### Review

Turn on a screenreader und use it on the video example-page.
