### PR TITLE
Fix/web components ready before listener added

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -39,10 +39,14 @@ export function defineElement(name, Class) {
     Class.compiledTemplate || hogan.compile(Class.template)
 
   if (window.WebComponents?.ready) {
-    window.customElements.define(name, Class)
+    if (!window.customElements.get(name)) {
+      window.customElements.define(name, Class)
+    }
   } else {
     window.addEventListener('WebComponentsReady', function() {
-      window.customElements.define(name, Class)
+      if (!window.customElements.get(name)) {
+        window.customElements.define(name, Class)
+      }
     })
   }
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -37,7 +37,12 @@ export function defineElement(name, Class) {
 
   Class.compiledTemplate =
     Class.compiledTemplate || hogan.compile(Class.template)
-  window.addEventListener('WebComponentsReady', function() {
+
+  if (window.WebComponents?.ready) {
     window.customElements.define(name, Class)
-  })
+  } else {
+    window.addEventListener('WebComponentsReady', function() {
+      window.customElements.define(name, Class)
+    })
+  }
 }


### PR DESCRIPTION
### Summary

If the "WebComponentsReady" event is triggered before the custom elements (Twitter & Video) are created, they will not be initialized. In addition, there was the problem that the elements were added multiple times on a single-page application (such as next.js) and an error was thrown.