### PR TITLE
fix(server): use high-res youtube image url for poster image

### DIFF
--- a/libs/base/src/youtube-video.ts
+++ b/libs/base/src/youtube-video.ts
@@ -12,6 +12,6 @@ export class YoutubeVideo extends Video<YoutubeVideoData> {
   }
 
   get posterImageUrl() {
-    return `https://img.youtube.com/vi/${this.id}/hqdefault.jpg`
+    return `https://img.youtube.com/vi/${this.id}/maxresdefault.jpg`
   }
 }


### PR DESCRIPTION
### Summary

Fixes #427 by switching to a different poster url for youtube videos.

### Motivation

Make youtube video posters great again.

### Review

Add a youtube embed to a page. See that the image is much higher quality than before and that the aspect ratio is correct gain.